### PR TITLE
Added setTextAlign to SingleDateAndTimePickerDialog.Builder

### DIFF
--- a/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/SingleDatePickerMainActivityWithDoublePicker.java
+++ b/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/SingleDatePickerMainActivityWithDoublePicker.java
@@ -39,7 +39,6 @@ public class SingleDatePickerMainActivityWithDoublePicker extends AppCompatActiv
     @BindView(R.id.singleDateLocaleText)
     TextView singleDateLocaleText;
 
-
     SimpleDateFormat simpleDateFormat;
     SimpleDateFormat simpleTimeFormat;
     SimpleDateFormat simpleDateOnlyFormat;
@@ -304,5 +303,24 @@ public class SingleDatePickerMainActivityWithDoublePicker extends AppCompatActiv
                     }
                 });
         singleBuilder.display();
+    }
+
+    @OnClick(R.id.datePickerAlignment)
+    public void dateAlignmentClicked() {
+        singleBuilder = new SingleDateAndTimePickerDialog.Builder(this)
+                .titleTextSize(17)
+                .bottomSheet()
+                .curved()
+                .displayMinutes(true)
+                .displayHours(true)
+                .displayAmPm(true)
+                .displayDays(false)
+                .displayDaysOfMonth(true)
+                .displayMonth(true)
+                .displayYears(true)
+                .setTextAlign(SingleDateAndTimePicker.ALIGN_LEFT);
+
+        singleBuilder.display();
+
     }
 }

--- a/app/src/main/res/layout/single_date_picker_activity_main_double_picker.xml
+++ b/app/src/main/res/layout/single_date_picker_activity_main_double_picker.xml
@@ -167,6 +167,35 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/datePickerAlignment"
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            >
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginRight="20dp"
+                app:srcCompat="@drawable/ic_event_available_black_24dp"
+                />
+
+            <TextView
+                android:id="@+id/datePickerAlignmentText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:textSize="15sp"
+                android:text="Click me to open single dialog for DATE with custom alignment"
+                android:textColor="@color/textColor"
+                />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </LinearLayout>

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BaseDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BaseDialog.java
@@ -5,6 +5,8 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.github.florent37.singledateandtimepicker.SingleDateAndTimePicker;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -55,6 +57,8 @@ public abstract class BaseDialog {
 
     @Nullable
     protected Boolean isAmPm;
+
+    protected int textAlignment = SingleDateAndTimePicker.ALIGN_CENTER;
 
     protected SimpleDateFormat dayFormatter;
 

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
@@ -184,6 +184,8 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
         picker.setDisplayDaysOfMonth(displayDaysOfMonth);
         picker.setDisplayMinutes(displayMinutes);
         picker.setDisplayHours(displayHours);
+
+        picker.setTextAlign(textAlignment);
     }
 
     public SingleDateAndTimePickerDialog setListener(Listener listener) {
@@ -306,6 +308,11 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
         return this;
     }
 
+    private SingleDateAndTimePickerDialog setTextAlign(int alignment) {
+        this.textAlignment = alignment;
+        return this;
+    }
+
     @Override
     public void display() {
         super.display();
@@ -372,6 +379,7 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
         private boolean displayYears = false;
         private boolean displayMonthNumbers = false;
         private boolean focusable = false;
+        private int textAlignment = SingleDateAndTimePicker.ALIGN_CENTER;
 
         @Nullable
         private Boolean isAmPm;
@@ -546,6 +554,11 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
             return this;
         }
 
+        public Builder setTextAlign(int alignment) {
+            this.textAlignment = alignment;
+            return this;
+        }
+
         public SingleDateAndTimePickerDialog build() {
             final SingleDateAndTimePickerDialog dialog = new SingleDateAndTimePickerDialog(context, bottomSheet)
                     .setTitle(title)
@@ -569,7 +582,8 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
                     .setCustomLocale(customLocale)
                     .setMustBeOnFuture(mustBeOnFuture)
                     .setTimeZone(timeZone)
-                    .setFocusable(focusable);
+                    .setFocusable(focusable)
+                    .setTextAlign(textAlignment);
 
             if (mainColor != null) {
                 dialog.setMainColor(mainColor);


### PR DESCRIPTION
This will add the ability to set the text alignment from the **SingleDateAndTimePickerDialog.Builder**.

Sample builder

```
singleBuilder = new SingleDateAndTimePickerDialog.Builder(this)
                .titleTextSize(17)
                .bottomSheet()
                .curved()
                .displayMinutes(true)
                .displayHours(true)
                .displayAmPm(true)
                .displayDays(false)
                .displayDaysOfMonth(true)
                .displayMonth(true)
                .displayYears(true)
                .setTextAlign(SingleDateAndTimePicker.ALIGN_LEFT); // Sets the text alignment, SingleDateAndTimePicker.ALIGN_CENTER by default
```